### PR TITLE
Wifi切断対策としてNetworkManagerの起動遅延。本当はKDE Walletの自動ロック解除かWifiパスワードをシステムワイドにするかするのが根本対策。

### DIFF
--- a/letsnote/config.nix
+++ b/letsnote/config.nix
@@ -168,7 +168,11 @@ in {
 
   # List services that you want to enable:
 
-  # Enable the OpenSSH daemon.
+  systemd.services.NetworkManager-wait-online = {
+    serviceConfig = {
+      ExecStart = [ "" "${pkgs.networkmanager}/bin/nm-online -q --timeout=30" ];
+    };
+  };
   services = {
     openssh = {
       enable = true;


### PR DESCRIPTION
#37
根本対策になっているかは不明
