### PR TITLE
Nvidia GPUで問題無くスリープするように

### DIFF
--- a/mypc/config.nix
+++ b/mypc/config.nix
@@ -119,18 +119,12 @@ in {
   services.xserver.videoDrivers = [ "nvidia" ];
   hardware.nvidia = {
     modesetting.enable = true;
-    # powerManagement.enable = false;
-    # powerManagement.finegrained = false;
-    # # prime.offload.enable = true;
+    powerManagement.enable = true;
     # open MUST false WHEN older than Turig (GTX16XX)
     open = true;
     nvidiaSettings = true;
     # package = config.boot.kernelPackages.nvidiaPackages.beta;
   };
-  boot.extraModprobeConfig = ''
-    options nvidia NVreg_PreserveVideoMemoryAllocations=1
-    options nvidia NVreg_TemporaryFilePath=/var/tmp
-  '';
 
   # Enable sound with pipewire.
   services.pulseaudio.enable = false;


### PR DESCRIPTION
- **nvidiaを無効化。これと前のcommitの間で安全圏を探る**
- **nvidiaが動作する最小構成だが、やはり復帰するとおかしくなる**
- **sleep/resumeしても正常に動作するように。ただし、sleepしても画面が消えず、ログイン画面がついたままになる**
- **正常にsleep/resumeするように**
#68
