### PR TITLE
デバッグ用プログラムをinstallする

### DIFF
--- a/component/packages.nix
+++ b/component/packages.nix
@@ -3,6 +3,8 @@ with pkgs; [
   procs
   fd
   libgcc
+  libinput
+  usbutils
   pciutils
   nil
   nixfmt-classic


### PR DESCRIPTION
マウスが重い根本原因はマウスの電池の接触不良だった
#77
