### PR TITLE
flakeを更新

### DIFF
--- a/mypc/flake.lock
+++ b/mypc/flake.lock
@@ -770,11 +770,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752544651,
-        "narHash": "sha256-GllP7cmQu7zLZTs9z0J2gIL42IZHa9CBEXwBY9szT0U=",
+        "lastModified": 1754988908,
+        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2c8def626f54708a9c38a5861866660395bb3461",
+        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
XremapのFlakeが更新すると不具合を発生させた原因だった
- **update home-manager #25**
- **update plasma-manager #25**
- **update nixos-hardware #25**
- **update nixvim #25**
- **update sops-nix #25**
