### PR TITLE
network

### DIFF
--- a/mypc/containers/default.nix
+++ b/mypc/containers/default.nix
@@ -1,9 +1,15 @@
 { ... }: {
-  networking.nat = {
-    enable = true;
-    internalInterfaces = [ "ve-*" ];
-    externalInterface = "enp5s0";
-    enableIPv6 = false;
+  networking = {
+    nat = {
+      enable = true;
+      internalInterfaces = [ "ve-*" ];
+      externalInterface = "enp5s0";
+      enableIPv6 = false;
+    };
+    firewall = {
+      filterForward = true;
+      trustedInterfaces = [ "ve-*" ];
+    };
   };
   imports = [
     ./llama


### PR DESCRIPTION
- **update nixpkgs 8/1 #25**
- **KDE Plasma用の設定を追加**
- **update nixpkgs 8/7 #25**
- **remove alacritty**
- **コンテナ内のUIDをホストから分離**
- **ACMEサーバによる証明書更新できなくなっていた問題を修正**
- **旧バージョンのgitea設定を削除**
- **受信せず通過する通信のフィルタを設定**
